### PR TITLE
:twisted_rightwards_arrows: Resolve permissions at CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,6 +5,9 @@ name: Checks
 # trigger workflow on push to any branch
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test-lint:
     # user friendly name


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration by adding minimal permissions for the workflow. The change explicitly sets the workflow's permissions to read-only for repository contents, which is a security best practice.